### PR TITLE
pin trivy-action to v0.35.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true

--- a/.github/workflows/render-test.yml
+++ b/.github/workflows/render-test.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true


### PR DESCRIPTION
As a follow-up to the Trivy supply chain attack (GHSA-69fq-xp46-6x23), pin aquasecurity/trivy-action to the first safe immutable release v0.35.0 instead of @master.
More details: https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23#user-content-fn-2-bea277abaada2a7b0363d2ae87379d10

We have thoroughly investigated the attack window (2026-03-19 17:43 UTC to 2026-03-20 05:40 UTC) and confirmed that our workflow runs during that period did not execute the malicious commit. We were not affected.

Going forward, all GitHub Actions references will be pinned to immutable versions to prevent exposure to similar tag-hijacking attacks.